### PR TITLE
feat(internal): omit TF_CLI_ARGS when 'version' command is called

### DIFF
--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -70,6 +70,8 @@ func (c *VersionCommand) Run(args []string) int {
 	cmdFlags.Bool("v", true, "version")
 	cmdFlags.Bool("version", true, "version")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
+	args = make([]string, 0)
+
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s\n", err.Error()))
 		return 1


### PR DESCRIPTION
Omit the any given arguments when `terraform version` is called.

Issue:  

```sh
$ terraform version
Terraform v1.0.2

$ export TF_CLI_ARGS="-var-file=example.tfvars"

$ terraform version
Error parsing command-line flags: flag provided but not defined: -var-file
```

Signed-off-by: Yagiz Degirmenci <yagizcanilbey1903@gmail.com>